### PR TITLE
Rolling back ESU linkage fix.

### DIFF
--- a/Azure_Arc/Enable-WindowsServerManagementByAzureArc.ps1
+++ b/Azure_Arc/Enable-WindowsServerManagementByAzureArc.ps1
@@ -527,15 +527,28 @@ function EnrollMachine {
     [System.String]$AbsoluteURI = $URI.AbsoluteUri
     [System.String]$ContentType = 'application/json'
 
-    Write-Information -MessageData "Getting current state of Arc-enabled Server: '$MachineName'."
-    $GetCurrentState = Invoke-RestMethod -Method 'GET' -Uri $AbsoluteURI -ContentType $ContentType -Headers $BearerTokenHeaderTable
-    $GetCurrentState.properties.softwareAssurance.softwareAssuranceCustomer = $true
-    $NewState = $GetCurrentState.properties | Select-Object -ExcludeProperty 'productProfile', 'provisioningState'
+    # 02.20.2025 - To do - the 'softwareAssurance' and 'softwareAssuranceCustomer' properties can be missing on an Arc-enabled Server.
+    # So, rolling back change which fixed ESU linkage until this is resolved so that enablement can still occur.
+    # Write-Information -MessageData "Getting current state of Arc-enabled Server: '$MachineName'."
+    # $GetCurrentState = Invoke-RestMethod -Method 'GET' -Uri $AbsoluteURI -ContentType $ContentType -Headers $BearerTokenHeaderTable
+    # $GetCurrentState.properties.softwareAssurance.softwareAssuranceCustomer = $true
+    # $NewState = $GetCurrentState.properties | Select-Object -ExcludeProperty 'productProfile', 'provisioningState'
+
+    # [System.Collections.Hashtable]$DataTable = @{
+    #     location   = $MachineLocation;
+    #     properties = $NewState
+    # };
 
     [System.Collections.Hashtable]$DataTable = @{
         location   = $MachineLocation;
-        properties = $NewState
+        properties = @{
+            softwareAssurance = @{
+                softwareAssuranceCustomer = $true;
+            };
+        };
     };
+
+    Write-Verbose -Message "URI: $AbsoluteURI"
 
     Write-Information -MessageData 'Building response table...'
     $JSON = $DataTable | ConvertTo-Json -Depth 50;

--- a/Azure_Arc/Set-WindowsServerManagementByAzureArc.ps1
+++ b/Azure_Arc/Set-WindowsServerManagementByAzureArc.ps1
@@ -571,20 +571,38 @@ function SetEnrollmentState {
     switch ($EnrollmentState) {
         'Enable' {
             Write-Information -MessageData "Set to enable Windows Server Management by Azure Arc on Server: '$MachineName'."
-            $GetCurrentState.properties.softwareAssurance.softwareAssuranceCustomer = $true
+            # 02.20.2025 - To do - the 'softwareAssurance' and 'softwareAssuranceCustomer' properties can be missing on an Arc-enabled Server.
+            # So, rolling back change which fixed ESU linkage until this is resolved so that enablement can still occur.
+            #$GetCurrentState.properties.softwareAssurance.softwareAssuranceCustomer = $true
+            [System.Collections.Hashtable]$DataTable = @{
+                location   = $MachineLocation;
+                properties = @{
+                    softwareAssurance = @{
+                        softwareAssuranceCustomer = $true;
+                    };
+                };
+            };
         }
         'Disable' {
             Write-Information -MessageData "Set to disable Windows Server Management by Azure Arc on Server: '$MachineName'."
-            $GetCurrentState.properties.softwareAssurance.softwareAssuranceCustomer = $false
+            #$GetCurrentState.properties.softwareAssurance.softwareAssuranceCustomer = $false
+            [System.Collections.Hashtable]$DataTable = @{
+                location   = $MachineLocation;
+                properties = @{
+                    softwareAssurance = @{
+                        softwareAssuranceCustomer = $false;
+                    };
+                };
+            };
         }
     }
 
-    $NewState = $GetCurrentState.properties | Select-Object -ExcludeProperty 'productProfile', 'provisioningState'
+    # $NewState = $GetCurrentState.properties | Select-Object -ExcludeProperty 'productProfile', 'provisioningState'
 
-    [System.Collections.Hashtable]$DataTable = @{
-        location   = $MachineLocation;
-        properties = $NewState
-    };
+    # [System.Collections.Hashtable]$DataTable = @{
+    #     location   = $MachineLocation;
+    #     properties = $NewState
+    # };
 
     Write-Information -MessageData 'Building response table...'
     $JSON = $DataTable | ConvertTo-Json -Depth 50;


### PR DESCRIPTION
Rolling back ESU linkage fix after discovering the 'softwareAssurance' and 'softwareAssuranceCustomer' properties can be missing from an Arc-enabled Server. This requires additional testing to finally resolve.