### PR TITLE
Revised & Tested Az. Gov. functionality

### DIFF
--- a/Azure_Arc/Enable-WSMgmtByAzureArc_Runbook.ps1
+++ b/Azure_Arc/Enable-WSMgmtByAzureArc_Runbook.ps1
@@ -226,12 +226,12 @@ function EnrollMachine {
             Mandatory = $false
         )]
         [ValidateSet(
-            'https://management.azure.com',
-            'https://management.usgovcloudapi.net',
-            'https://management.microsoftazure.de',
-            'https://management.chinacloudapi.cn'
+            'https://management.azure.com/',
+            'https://management.usgovcloudapi.net/',
+            'https://management.microsoftazure.de/',
+            'https://management.chinacloudapi.cn/'
         )]
-        [System.String]$ResourceManagerURL = 'https://management.azure.com'
+        [System.String]$ResourceManagerURL = 'https://management.azure.com/'
     )
     [System.String]$ThisFunctionName = $MyInvocation.MyCommand
     Write-Verbose -Message "Running: '$ThisFunctionName'."
@@ -239,8 +239,8 @@ function EnrollMachine {
     [System.String]$MachineName = $Machine.name
     [System.String]$MachineResourceGroupName = $Machine.resourceGroup
     [System.String]$MachineLocation = $Machine.Location
-    [System.String]$GETURI = [System.String]::Concat($ResourceManagerURL,'/subscriptions/', $MachineSubscriptionID, '/resourceGroups/', $MachineResourceGroupName, '/providers/Microsoft.HybridCompute/machines/', $MachineName, '?api-version=', $ARMAPIVersion)
-    [System.String]$PUTURI = [System.String]::Concat($ResourceManagerURL,'/subscriptions/', $MachineSubscriptionID, '/resourceGroups/', $MachineResourceGroupName, '/providers/Microsoft.HybridCompute/machines/', $MachineName, '/licenseProfiles/default?api-version=', $ARMAPIVersion)
+    [System.String]$GETURI = [System.String]::Concat($ResourceManagerURL,'subscriptions/', $MachineSubscriptionID, '/resourceGroups/', $MachineResourceGroupName, '/providers/Microsoft.HybridCompute/machines/', $MachineName, '?api-version=', $ARMAPIVersion)
+    [System.String]$PUTURI = [System.String]::Concat($ResourceManagerURL,'subscriptions/', $MachineSubscriptionID, '/resourceGroups/', $MachineResourceGroupName, '/providers/Microsoft.HybridCompute/machines/', $MachineName, '/licenseProfiles/default?api-version=', $ARMAPIVersion)
 
     [System.Uri]$PUTURIObj = [System.Uri]::new( $PUTURI )
     [System.String]$PUTAbsoluteURI = $PUTURIObj.AbsoluteUri

--- a/Azure_Arc/Enable-WSMgmtByAzureArc_Runbook.ps1
+++ b/Azure_Arc/Enable-WSMgmtByAzureArc_Runbook.ps1
@@ -431,7 +431,7 @@ if (1 -le $MachinesArrayCount) {
 
         Write-Verbose -Message "Working on server: '$MachineName'. Server: '$j' of: '$MachinesArrayCount' servers."
         ## Enrollment
-        $Response = EnrollMachine -Machine $Machine -BearerTokenHeaderTable $BearerTokenHeaderTable
+        $Response = EnrollMachine -ResourceManagerURL $AzureResourceManagerURL -Machine $Machine -BearerTokenHeaderTable $BearerTokenHeaderTable
 
         $ResponseArray.Add($Response) | Out-Null
 

--- a/Azure_Arc/Enable-WindowsServerManagementByAzureArc.ps1
+++ b/Azure_Arc/Enable-WindowsServerManagementByAzureArc.ps1
@@ -507,12 +507,12 @@ function EnrollMachine {
             Mandatory = $false
         )]
         [ValidateSet(
-            'https://management.azure.com',
-            'https://management.usgovcloudapi.net',
-            'https://management.microsoftazure.de',
-            'https://management.chinacloudapi.cn'
+            'https://management.azure.com/',
+            'https://management.usgovcloudapi.net/',
+            'https://management.microsoftazure.de/',
+            'https://management.chinacloudapi.cn/'
         )]
-        [System.String]$ResourceManagerURL = 'https://management.azure.com'
+        [System.String]$ResourceManagerURL = 'https://management.azure.com/'
     )
     [System.String]$ThisFunctionName = $MyInvocation.MyCommand
     Write-Verbose -Message "Running: '$ThisFunctionName'."
@@ -520,8 +520,8 @@ function EnrollMachine {
     [System.String]$MachineName = $Machine.name
     [System.String]$MachineResourceGroupName = $Machine.resourceGroup
     [System.String]$MachineLocation = $Machine.Location
-    [System.String]$GETURI = [System.String]::Concat($ResourceManagerURL,'/subscriptions/', $MachineSubscriptionID, '/resourceGroups/', $MachineResourceGroupName, '/providers/Microsoft.HybridCompute/machines/', $MachineName, '?api-version=', $ARMAPIVersion)
-    [System.String]$PUTURI = [System.String]::Concat($ResourceManagerURL,'/subscriptions/', $MachineSubscriptionID, '/resourceGroups/', $MachineResourceGroupName, '/providers/Microsoft.HybridCompute/machines/', $MachineName, '/licenseProfiles/default?api-version=', $ARMAPIVersion)
+    [System.String]$GETURI = [System.String]::Concat($ResourceManagerURL,'subscriptions/', $MachineSubscriptionID, '/resourceGroups/', $MachineResourceGroupName, '/providers/Microsoft.HybridCompute/machines/', $MachineName, '?api-version=', $ARMAPIVersion)
+    [System.String]$PUTURI = [System.String]::Concat($ResourceManagerURL,'subscriptions/', $MachineSubscriptionID, '/resourceGroups/', $MachineResourceGroupName, '/providers/Microsoft.HybridCompute/machines/', $MachineName, '/licenseProfiles/default?api-version=', $ARMAPIVersion)
 
     [System.Uri]$PUTURIObj = [System.Uri]::new( $PUTURI )
     [System.String]$PUTAbsoluteURI = $PUTURIObj.AbsoluteUri

--- a/Azure_Arc/Enable-WindowsServerManagementByAzureArc.ps1
+++ b/Azure_Arc/Enable-WindowsServerManagementByAzureArc.ps1
@@ -834,10 +834,10 @@ if (1 -le $MachinesArrayCount) {
         Write-Information -MessageData "Working on server: '$MachineName'. Server: '$j' of: '$MachinesArrayCount' servers."
 
         if ($PSBoundParameters.ContainsKey('ReportOnly')) {
-            $Response = EnrollMachine -Machine $Machine -BearerTokenHeaderTable $BearerTokenHeaderTable -WhatIf
+            $Response = EnrollMachine -ResourceManagerURL $AzureResourceManagerURL -Machine $Machine -BearerTokenHeaderTable $BearerTokenHeaderTable -WhatIf
         }
         else {
-            $Response = EnrollMachine -Machine $Machine -BearerTokenHeaderTable $BearerTokenHeaderTable
+            $Response = EnrollMachine -ResourceManagerURL $AzureResourceManagerURL -Machine $Machine -BearerTokenHeaderTable $BearerTokenHeaderTable
         }
 
         $ResponseArray.Add($Response) | Out-Null

--- a/Azure_Arc/Set-WindowsServerManagementByAzureArc.ps1
+++ b/Azure_Arc/Set-WindowsServerManagementByAzureArc.ps1
@@ -558,8 +558,8 @@ function SetEnrollmentState {
     [System.String]$MachineName = $Machine.name
     [System.String]$MachineResourceGroupName = $Machine.resourceGroup
     [System.String]$MachineLocation = $Machine.Location
-    [System.String]$GETURI = [System.String]::Concat($ResourceManagerURL,'/subscriptions/', $MachineSubscriptionID, '/resourceGroups/', $MachineResourceGroupName, '/providers/Microsoft.HybridCompute/machines/', $MachineName, '?api-version=', $ARMAPIVersion)
-    [System.String]$PUTURI = [System.String]::Concat($ResourceManagerURL,'/subscriptions/', $MachineSubscriptionID, '/resourceGroups/', $MachineResourceGroupName, '/providers/Microsoft.HybridCompute/machines/', $MachineName, '/licenseProfiles/default?api-version=', $ARMAPIVersion)
+    [System.String]$GETURI = [System.String]::Concat($ResourceManagerURL,'subscriptions/', $MachineSubscriptionID, '/resourceGroups/', $MachineResourceGroupName, '/providers/Microsoft.HybridCompute/machines/', $MachineName, '?api-version=', $ARMAPIVersion)
+    [System.String]$PUTURI = [System.String]::Concat($ResourceManagerURL,'subscriptions/', $MachineSubscriptionID, '/resourceGroups/', $MachineResourceGroupName, '/providers/Microsoft.HybridCompute/machines/', $MachineName, '/licenseProfiles/default?api-version=', $ARMAPIVersion)
 
     [System.Uri]$PUTURIObj = [System.Uri]::new( $PUTURI )
     [System.String]$PUTAbsoluteURI = $PUTURIObj.AbsoluteUri


### PR DESCRIPTION
Windows Server Management Enabled via Azure Arc functionality has been fixed to work in Azure Government.

- The ARM management URL wasn't being passed to functions to craft the correct GET and PUT URLs.
- Correct a few small double forward slashes in the URLs once the correct management URL was passed in.
- Fixed parameter set validation.